### PR TITLE
Added support for Font::Info family member

### DIFF
--- a/include/SFML/Graphics/Font.h
+++ b/include/SFML/Graphics/Font.h
@@ -132,5 +132,14 @@ CSFML_GRAPHICS_API int sfFont_getLineSpacing(sfFont* font, unsigned int characte
 ////////////////////////////////////////////////////////////
 CSFML_GRAPHICS_API const sfTexture* sfFont_getTexture(sfFont* font, unsigned int characterSize);
 
+////////////////////////////////////////////////////////////
+/// \brief Get the family member of this font's info struct (returns an ANSI string)
+///
+/// \param text Source font
+///
+/// \return String as a locale-dependant ANSI string
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API const char* sfFont_getInfoFamily(sfFont* font);
 
 #endif // SFML_IMAGE_H

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -155,3 +155,12 @@ const sfTexture* sfFont_getTexture(sfFont* font, unsigned int characterSize)
 
     return &font->Textures[characterSize];
 }
+
+
+////////////////////////////////////////////////////////////
+const char* sfFont_getInfoFamily(sfFont* font)
+{
+    CSFML_CHECK_RETURN(font, NULL);
+
+    return font->This.getInfo().family.c_str();
+}


### PR DESCRIPTION
https://github.com/LaurentGomila/SFML/commit/7caf2e64b6aa40c28367e736592c44976e58170f

If you want I can modify to the PR to actually add another struct type for the Font::Info type, I didn't in this version because I figured it would be overkill for something as a single string. If in the future that info struct ever has more members added it won't be any issue to add another function for that member.