### PR TITLE
Added sfTouch_getPositionRenderWindow(...) function

### DIFF
--- a/include/SFML/Graphics/RenderWindow.h
+++ b/include/SFML/Graphics/RenderWindow.h
@@ -511,20 +511,20 @@ CSFML_GRAPHICS_API void sfRenderWindow_resetGLStates(sfRenderWindow* renderWindo
 CSFML_GRAPHICS_API sfImage* sfRenderWindow_capture(const sfRenderWindow* renderWindow);
 
 ////////////////////////////////////////////////////////////
-/// \brief Get the current position of the mouse relatively to a render-window
+/// \brief Get the current position of the mouse relative to a render-window
 ///
 /// This function returns the current position of the mouse
 /// cursor relative to the given render-window, or desktop if NULL is passed.
 ///
 /// \param relativeTo Reference window
 ///
-/// \return Position of the mouse cursor, relative to the given render-window
+/// \return Position of the mouse cursor, relative to the given render window
 ///
 ////////////////////////////////////////////////////////////
 CSFML_GRAPHICS_API sfVector2i sfMouse_getPositionRenderWindow(const sfRenderWindow* relativeTo);
 
 ////////////////////////////////////////////////////////////
-/// \brief Set the current position of the mouse relatively to a render-window
+/// \brief Set the current position of the mouse relative to a render window
 ///
 /// This function sets the current position of the mouse
 /// cursor relative to the given render-window, or desktop if NULL is passed.
@@ -534,6 +534,20 @@ CSFML_GRAPHICS_API sfVector2i sfMouse_getPositionRenderWindow(const sfRenderWind
 ///
 ////////////////////////////////////////////////////////////
 CSFML_GRAPHICS_API void sfMouse_setPositionRenderWindow(sfVector2i position, const sfRenderWindow* relativeTo);
+
+////////////////////////////////////////////////////////////
+/// \brief Get the current position of a touch in window coordinates
+///
+/// This function returns the current touch position
+/// relative to the given render window, or desktop if NULL is passed.
+///
+/// \param finger Finger index
+/// \param relativeTo Reference window
+///
+/// \return Current position of \a finger, or undefined if it's not down
+///
+////////////////////////////////////////////////////////////
+CSFML_GRAPHICS_API sfVector2i sfTouch_getPositionRenderWindow(unsigned int finger, const sfRenderWindow* relativeTo);
 
 
 #endif // SFML_RENDERWINDOW_H

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -36,6 +36,7 @@
 #include <SFML/Graphics/RectangleShapeStruct.h>
 #include <SFML/Graphics/VertexArrayStruct.h>
 #include <SFML/Graphics/ConvertRenderStates.hpp>
+#include <SFML/Window/Touch.hpp>
 #include <SFML/Internal.h>
 #include <SFML/ConvertEvent.h>
 
@@ -532,4 +533,18 @@ void sfMouse_setPositionRenderWindow(sfVector2i position, const sfRenderWindow* 
         sf::Mouse::setPosition(sf::Vector2i(position.x, position.y), relativeTo->This);
     else
         sf::Mouse::setPosition(sf::Vector2i(position.x, position.y));
+}
+
+////////////////////////////////////////////////////////////
+sfVector2i sfTouch_getPositionRenderWindow(unsigned int finger, const sfRenderWindow* relativeTo)
+{
+    sf::Vector2i sfmlPosition;
+
+    if (relativeTo)
+        sfmlPosition = sf::Touch::getPosition(finger, relativeTo->This);
+    else
+        sfmlPosition = sf::Touch::getPosition(finger);
+
+    sfVector2i position = { sfmlPosition.x, sfmlPosition.y };
+    return position;
 }


### PR DESCRIPTION
This is required to get a touch position relative to a render window (same as getting a mouse position).