### PR TITLE
Fix pointer conversion warning when compiling without NDEBUG on Linux

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -317,7 +317,7 @@ void sfWindow_setJoystickThreshold(sfWindow* window, float threshold)
 ////////////////////////////////////////////////////////////
 sfWindowHandle sfWindow_getSystemHandle(const sfWindow* window)
 {
-    CSFML_CHECK_RETURN(window, NULL);
+    CSFML_CHECK_RETURN(window, 0);
 
     return (sfWindowHandle)window->This.getSystemHandle();
 }


### PR DESCRIPTION
GCC doesn't like this NULL to integer conversion. Since this is C++, using 0 should work for both pointers and integers.

```
src/SFML/Window/Window.cpp:320:5: warning: converting to non-pointer type ‘sfWindowHandle {aka long unsigned int}’ from NULL [-Wconversion-null]
     CSFML_CHECK_RETURN(window, NULL);
     ^
```