### PR TITLE
Changed getSampleCount return type to sfUint64 to better match SFML

### DIFF
--- a/include/SFML/Audio/SoundBuffer.h
+++ b/include/SFML/Audio/SoundBuffer.h
@@ -152,7 +152,7 @@ CSFML_AUDIO_API const sfInt16* sfSoundBuffer_getSamples(const sfSoundBuffer* sou
 /// \return Number of samples
 ///
 ////////////////////////////////////////////////////////////
-CSFML_AUDIO_API size_t sfSoundBuffer_getSampleCount(const sfSoundBuffer* soundBuffer);
+CSFML_AUDIO_API sfUint64 sfSoundBuffer_getSampleCount(const sfSoundBuffer* soundBuffer);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the sample rate of a sound buffer

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -125,7 +125,7 @@ const sfInt16* sfSoundBuffer_getSamples(const sfSoundBuffer* soundBuffer)
 
 
 ////////////////////////////////////////////////////////////
-size_t sfSoundBuffer_getSampleCount(const sfSoundBuffer* soundBuffer)
+sfUint64 sfSoundBuffer_getSampleCount(const sfSoundBuffer* soundBuffer)
 {
     CSFML_CALL_RETURN(soundBuffer, getSampleCount(), 0);
 }


### PR DESCRIPTION
I noticed that when compiling I was getting an error of possible loss of data from a conversion. I checked it out and ```sf::SoundBuffer::getSampleCount()``` returns a Uint64, but the CSFML function returns a size_t which is only a uint32 on 32bit compilers.